### PR TITLE
Fix issues with OIDC admin configuration and LDAP admin reference

### DIFF
--- a/configs/authorizers.xml
+++ b/configs/authorizers.xml
@@ -50,8 +50,10 @@
         {{- range $i := until $replicas }}
         <property name="Initial User Identity {{ $i }}">CN={{ $fullname }}-{{ $i }}.{{ $fullname }}-headless.{{ $namespace }}.svc.cluster.local, OU=NIFI</property>
         {{- end }}
-        {{- if and .Values.auth.ldap.enabled (not .Values.auth.admin) }}
-        <property name="Initial User Identity admin">{{.Values.auth.ldap.admin}}</property>
+        {{- if and .Values.auth.ldap.enabled }}
+        <property name="Initial User Identity 1">{{.Values.auth.ldap.admin}}</property>
+        {{- else if and .Values.auth.oidc.enabled }}
+        <property name="Initial User Identity 1">{{.Values.auth.oidc.admin}}</property>
         {{- else }}
         <property name="Initial User Identity admin">{{ .Values.auth.admin }}</property>
         {{- end}}
@@ -222,8 +224,10 @@
         <class>org.apache.nifi.authorization.FileAccessPolicyProvider</class>
         <property name="User Group Provider">file-user-group-provider</property>
         <property name="Authorizations File">./auth-conf/authorizations.xml</property>
-        {{- if and .Values.auth.ldap.enabled (not .Values.auth.admin) }}
+        {{- if and .Values.auth.ldap.enabled }}
         <property name="Initial Admin Identity">{{.Values.auth.ldap.admin}}</property>
+        {{- else if and .Values.auth.oidc.enabled }}
+        <property name="Initial Admin Identity">{{.Values.auth.oidc.admin}}</property>
         {{- else }}
         <property name="Initial Admin Identity">{{ .Values.auth.admin }}</property>
         {{- end}}

--- a/values.yaml
+++ b/values.yaml
@@ -123,8 +123,8 @@ properties:
 
 # Nifi User Authentication
 auth:
-  # If set while LDAP is enabled, this value will be used for the initial admin and not the ldap bind dn / admin
-  admin: CN=admin, OU=NIFI
+  # If set while LDAP or oidc enabled, this value is ignored and not used as the initial admin.
+  admin: CN=admin, OU=NIFI 
   SSL:
     keystorePasswd: changeMe
     truststorePasswd: changeMe


### PR DESCRIPTION
- Fixed an issue where the admin was not properly configured when using OIDC.
- Resolved a problem where auth.ldap.admin was not referenced if auth.admin was set, despite LDAP being enabled.

