### PR TITLE
Make 'repository.archive.enabled' setting configurable

### DIFF
--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -77,7 +77,7 @@ nifi.content.claim.max.flow.files=100
 nifi.content.repository.directory.default=../content_repository
 nifi.content.repository.archive.max.retention.period={{.Values.properties.archiveMaxRetentionPeriod}}
 nifi.content.repository.archive.max.usage.percentage={{.Values.properties.archiveMaxUsagePercentage}}
-nifi.content.repository.archive.enabled=true
+nifi.content.repository.archive.enabled={{.Values.properties.archiveEnabled}}
 nifi.content.repository.always.sync=false
 nifi.content.viewer.url=/nifi-content-viewer/
 

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,7 @@ properties:
   zookeeperSessionTimeout: '3 secs'
   archiveMaxRetentionPeriod: "3 days"
   archiveMaxUsagePercentage: "85%"
+  archiveEnabled: true
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"
   flowArchiveMaxTime: "30 days"


### PR DESCRIPTION
This change makes the repository archive setting configurable. In our use case keeping archive increases the disk usage without clear benefit.